### PR TITLE
Updating to React 15.5 and fix warning to use prop-types library

### DIFF
--- a/lib/Google.js
+++ b/lib/Google.js
@@ -12,6 +12,10 @@ var _react = require('react');
 
 var _react2 = _interopRequireDefault(_react);
 
+var _propTypes = require('prop-types');
+
+var _propTypes2 = _interopRequireDefault(_propTypes);
+
 var _reactLeaflet = require('react-leaflet');
 
 var _leaflet = require('./leaflet.google');
@@ -69,8 +73,8 @@ var GoogleLayer = function (_GridLayer) {
 }(_reactLeaflet.GridLayer);
 
 GoogleLayer.propTypes = {
-  googlekey: _react.PropTypes.string.isRequired,
-  maptype: _react.PropTypes.string,
-  asclientid: _react.PropTypes.bool
+  googlekey: _propTypes2.default.string.isRequired,
+  maptype: _propTypes2.default.string,
+  asclientid: _propTypes2.default.bool
 };
 exports.default = GoogleLayer;

--- a/package.json
+++ b/package.json
@@ -50,10 +50,11 @@
     "google-maps": "^3.2.1",
     "leaflet": "^1.0.2",
     "lodash.isequal": "^4.4.0",
-    "react": "^15.4.1",
-    "react-dom": "^15.4.1",
+    "react": "^15.5.0",
+    "react-dom": "^15.5.0",
     "react-leaflet": "^1.0.1",
     "webpack": "^1.13.0",
-    "webpack-dev-server": "^1.12.1"
+    "webpack-dev-server": "^1.12.1",
+    "prop-types": "^15.5.10"
   }
 }

--- a/src/Google.js
+++ b/src/Google.js
@@ -1,4 +1,5 @@
-import React, {PropTypes}  from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import {GridLayer} from 'react-leaflet';
 import {Google} from './leaflet.google';
 
@@ -9,8 +10,6 @@ export default class GoogleLayer extends GridLayer {
     maptype: PropTypes.string,
     asclientid: PropTypes.bool
   };
-
-
 
   componentWillMount() {
     super.componentWillMount();


### PR DESCRIPTION
Use prop-types module instead of React.PropTypes as described in React 15.5 migration guide.

https://facebook.github.io/react/blog/2017/04/07/react-v15.5.0.html