### PR TITLE
Added channel option for Maps premium plan 

### DIFF
--- a/src/Google.js
+++ b/src/Google.js
@@ -8,7 +8,8 @@ export default class GoogleLayer extends GridLayer {
   static propTypes = {
     googlekey: PropTypes.string.isRequired,
     maptype: PropTypes.string,
-    asclientid: PropTypes.bool
+    asclientid: PropTypes.bool,
+    channel: PropTypes.string
   };
 
 
@@ -20,7 +21,7 @@ export default class GoogleLayer extends GridLayer {
 
   componentWillMount() {
     super.componentWillMount();
-    const {map: _map, googlekey, maptype, asclientid, ...props} = this.props;
+    const {map: _map, googlekey, maptype, asclientid, channel, ...props} = this.props;
     this.leafletElement = new L.gridLayer.googleMutant(this.props);
   }
 

--- a/src/leaflet.google.js
+++ b/src/leaflet.google.js
@@ -37,6 +37,10 @@ L.GridLayer.GoogleMutant = L.GridLayer.extend({
 
     GoogleMapsLoader.LIBRARIES = options.libraries || [];
 
+    if (options.channel) {
+      GoogleMapsLoader.CHANNEL = options.channel;
+    }
+
     self._type = options.maptype || 'SATELLITE';
 
     GoogleMapsLoader.load(function (_google) {


### PR DESCRIPTION
Premium plan for Maps supports setting a channel parameter (https://developers.google.com/maps/premium/overview#client-id).
Added option for setting channel as prop.