### PR TITLE
Update leaflet.google.js

### DIFF
--- a/src/leaflet.google.js
+++ b/src/leaflet.google.js
@@ -88,7 +88,8 @@ L.GridLayer.GoogleMutant = L.GridLayer.extend({
         map.on("resize", this._resize, this);
         
         // 20px instead of 1em to avoid a slight overlap with google's attribution
-        map._controlCorners.bottomright.style.marginBottom = "20px";
+        if ( map._controlCorners )
+          map._controlCorners.bottomright.style.marginBottom = "20px";
         
         this._reset();
         this._update();


### PR DESCRIPTION
I get `TypeError: cannot read property 'bottomright' of undefined` and it points to this line. It's doesn't happen every single page refresh so it's more to do with concurrency. I'm suggesting this simple change to prevent the google map not loading at all