### PR TITLE
Reverting maxNativeZoom

### DIFF
--- a/src/leaflet.google.js
+++ b/src/leaflet.google.js
@@ -14,7 +14,7 @@ L.GridLayer.GoogleMutant = L.GridLayer.extend({
   
   options: {
     minZoom: 0,
-    maxZoom: 18,
+    maxZoom: 21,
     tileSize: 256,
     subdomains: "abc",
     errorTileUrl: "",
@@ -25,7 +25,7 @@ L.GridLayer.GoogleMutant = L.GridLayer.extend({
     // 🍂option type: String = 'roadmap'
     // Google's map type. Valid values are 'roadmap', 'satellite' or 'terrain'. 'hybrid' is not really supported.
     type: "HYBRID",
-    maxNativeZoom: 18,
+    maxNativeZoom: 21,
   },
   
   initialize(options) {


### PR DESCRIPTION
maxNativeZoom was changed to 18 from 21 in one of the releases of this module, which breaks React Leaftlet's ability to display Google Maps tiles in the 21 zoom level, although they do exist.